### PR TITLE
use s6-overlay instead of s6 alpine package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,5 @@ ADD docker/ /
 
 RUN rm -rf /var/www/app/docker && echo $VERSION > /var/www/app/app/version.txt
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/init"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,20 @@ EXPOSE 80 443
 ARG VERSION
 
 RUN apk --no-cache --update add \
-    tzdata openssl unzip nginx bash ca-certificates curl ssmtp mailx php83 php83-phar php83-curl \
+    tzdata openssl unzip xz nginx bash ca-certificates curl ssmtp mailx php83 php83-phar php83-curl \
     php83-fpm php83-json php83-zlib php83-xml php83-dom php83-ctype php83-opcache php83-zip php83-iconv \
     php83-pdo php83-pdo_mysql php83-pdo_sqlite php83-pdo_pgsql php83-mbstring php83-session php83-bcmath \
     php83-gd php83-openssl php83-sockets php83-posix php83-ldap php83-simplexml php83-xmlwriter && \
     rm -rf /var/www/localhost && \
     rm -f /etc/php83/php-fpm.d/www.conf && \
     ln -sf /usr/bin/php83 /usr/bin/php
+
+ARG S6_OVERLAY_VERSION=3.2.0.2
+
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz
+ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
+RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz
 
 ADD . /var/www/app
 ADD docker/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ EXPOSE 80 443
 ARG VERSION
 
 RUN apk --no-cache --update add \
-    tzdata openssl unzip nginx bash ca-certificates s6 curl ssmtp mailx php83 php83-phar php83-curl \
+    tzdata openssl unzip nginx bash ca-certificates curl ssmtp mailx php83 php83-phar php83-curl \
     php83-fpm php83-json php83-zlib php83-xml php83-dom php83-ctype php83-opcache php83-zip php83-iconv \
     php83-pdo php83-pdo_mysql php83-pdo_sqlite php83-pdo_pgsql php83-mbstring php83-session php83-bcmath \
     php83-gd php83-openssl php83-sockets php83-posix php83-ldap php83-simplexml php83-xmlwriter && \

--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -1,4 +1,3 @@
-user nginx;
 worker_processes 1;
 pid /var/run/nginx.pid;
 

--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -22,22 +22,11 @@ http {
 
     server {
         listen                    80;
-        listen                    443 ssl;
         http2                     on;
         server_name               localhost;
         index                     index.php;
         root                      /var/www/app;
         client_max_body_size      32M;
-
-        # https://ssl-config.mozilla.org/#server=nginx&version=1.18.0&config=intermediate&openssl=1.1.1i&hsts=false&ocsp=false&guideline=5.6
-        ssl_certificate           /etc/nginx/ssl/kanboard.crt;
-        ssl_certificate_key       /etc/nginx/ssl/kanboard.key;
-        ssl_protocols             TLSv1.2 TLSv1.3;
-        ssl_ciphers               ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
-        ssl_prefer_server_ciphers off;
-        ssl_session_timeout       1d;
-        ssl_session_cache         shared:MozSSL:10m;
-        ssl_session_tickets       off;
 
         location / {
             try_files $uri $uri/ /index.php$is_args$args;

--- a/docker/etc/services.d/cron/run
+++ b/docker/etc/services.d/cron/run
@@ -1,2 +1,2 @@
-#!/bin/execlineb -P
+#!/command/execlineb -P
 crond -f

--- a/docker/etc/services.d/nginx/run
+++ b/docker/etc/services.d/nginx/run
@@ -1,3 +1,3 @@
-#!/bin/execlineb -P
+#!/command/execlineb -P
 
 nginx -g "daemon off;"

--- a/docker/etc/services.d/php/run
+++ b/docker/etc/services.d/php/run
@@ -1,2 +1,2 @@
-#!/bin/execlineb -P
+#!/command/with-contenv sh
 php-fpm83 -F


### PR DESCRIPTION
Hi 

**This is just a POC** that's why I don't make a real PR against <https://github.com/kanboard/kanboard>

---

I'm interested by a solution to <https://github.com/kanboard/kanboard/issues/4526>

Kanboard docker image actually use the `s6`  apk provided by Alpine <https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/s6> which is old

The `s6-overlay` project <https://github.com/just-containers/s6-overlay> developped by the same team as `s6` have basic support for the docker `USER` directive <https://github.com/just-containers/s6-overlay?tab=readme-ov-file#user-directive>

This PR illustrates a POC of usage to build and run successfully a kanboard docker image as a user other than `root`. It's just a POC (I insist :wink: ) with minimal changes to the original

- ssl key generation and ssl config of nginx isn't managed
- the `docker run --user uid:gid` is hardcoded to `100:101` (depends on the nginx user created by the alpine apk)
- it uses the legacy `/etc/services.d` of `s6` instead of the new `/etc/s6-overlay/s6-rc.d` see <https://github.com/just-containers/s6-overlay?tab=readme-ov-file#writing-a-service-script>
- I thing that logging of `cron` `nginx` and `php-fpm` services can be enhanced with logging capacities of `s6-overlay`

--- 

build of the image

```bash
[gregr:/export/home/lingr/github/kanboard] s6-overlay ± make docker-image
[+] Building 23.8s (16/16) FINISHED                                                                                     docker:default
 => [internal] load build definition from Dockerfile                                                                              0.2s
 => => transferring dockerfile: 1.71kB                                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:3.20                                                                    1.2s
 => [internal] load .dockerignore                                                                                                 0.1s
 => => transferring context: 276B                                                                                                 0.0s
 => CACHED [1/9] FROM docker.io/library/alpine:3.20@sha256:1e42bbe2508154c9126d48c2b8a75420c3544343bf86fd041fb7527e017a4b4a       0.0s
 => [internal] load build context                                                                                                 0.6s
 => => transferring context: 12.90MB                                                                                              0.5s
 => CACHED [5/9] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp       0.7s
 => [2/9] RUN apk --no-cache --update add     tzdata openssl unzip xz nginx bash ca-certificates curl ssmtp mailx php83 php83-ph  8.9s
 => CACHED [3/9] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp       0.7s
 => [3/9] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-noarch.tar.xz /tmp              0.8s 
 => [4/9] RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz                                                                        1.7s 
 => [5/9] ADD https://github.com/just-containers/s6-overlay/releases/download/v3.2.0.2/s6-overlay-x86_64.tar.xz /tmp              0.9s 
 => [6/9] RUN tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz                                                                        1.9s 
 => [7/9] ADD . /var/www/app                                                                                                      1.8s 
 => [8/9] ADD docker/ /                                                                                                           0.9s 
 => [9/9] RUN rm -rf /var/www/app/docker && echo main.4da40379f > /var/www/app/app/version.txt                                    1.6s
 => exporting to image                                                                                                            2.5s
 => => exporting layers                                                                                                           2.2s
 => => writing image sha256:d9ee759127105d3f224afe4feda581d924edb5648467d8568a4e7bfb913175d7                                      0.0s
 => => naming to docker.io/kanboard/kanboard:main
```

---

running the image as `101:101`. 

Beware, owner, group and perms on the volumes directories must corresponds

```bash
[gregr:~] $ ls -ldn /export/home/lingr/tmp/kanboard/data /export/home/lingr/tmp/kanboard/plugins
drwxrwxr-x 3 100 101 4096 nov.  14 11:09 /export/home/lingr/tmp/kanboard/data
drwxrwxr-x 2 100 101 4096 nov.  12 15:09 /export/home/lingr/tmp/kanboard/plugins
```
I've REDACTED some info
```bash
[gregr:~] $ docker run --rm \
> --user 100:101 \
> --publish 8080:80 \
> --volume /export/home/lingr/tmp/kanboard/data:/var/www/app/data:rw \
> --volume /export/home/lingr/tmp/kanboard/plugins:/var/www/app/plugins:rw \
> --env LOG_DRIVER=stdout \
> --env MAIL_CONFIGURATION=false \
> --env MAIL_FROM=noreply+kanboard@REDACTED \
> --env MAIL_TRANSPORT=smtp \
> --env MAIL_SMTP_HOSTNAME=smtp.REDACTED \
> --env DB_DRIVER=mysql \
> --env DB_HOSTNAME=vmysqlREDACTED \
> --env DB_NAME=kanboardprp \
> --env DB_USERNAME=kanboardprp \
> --env DB_PASSWORD=${DB_PASSWORD} \
> --env LDAP_AUTH=true \
> --env LDAP_SERVER=vldapREDACTED \
> --env LDAP_USER_BASE_DN="ou=annuaire,dc=REDACTED,dc=REDACTED" \
> --env LDAP_USER_FILTER="uid=%s" \
> --env LDAP_USER_CREATION=true \
> docker.io/kanboard/kanboard:main
/package/admin/s6-overlay/libexec/preinit: info: /run belongs to uid 0 instead of 100 - fixing it
s6-rc: info: service s6rc-oneshot-runner: starting
s6-rc: info: service s6rc-oneshot-runner successfully started
s6-rc: info: service fix-attrs: starting
s6-rc: info: service fix-attrs successfully started
s6-rc: info: service legacy-cont-init: starting
s6-rc: info: service legacy-cont-init successfully started
s6-rc: info: service legacy-services: starting
services-up: info: copying legacy longrun cron (no readiness notification)
services-up: info: copying legacy longrun nginx (no readiness notification)
services-up: info: copying legacy longrun php (no readiness notification)
s6-rc: info: service legacy-services successfully started
[14-Nov-2024 15:03:21 UTC] [info] Authenticate this user: uid=REDACTED,ou=annuaire,dc=REDACTED,dc=REDACTED"
s6-rc: info: service legacy-services: stopping
s6-rc: info: service legacy-services successfully stopped
s6-rc: info: service legacy-cont-init: stopping
s6-rc: info: service legacy-cont-init successfully stopped
s6-rc: info: service fix-attrs: stopping
s6-rc: info: service fix-attrs successfully stopped
s6-rc: info: service s6rc-oneshot-runner: stopping
s6-rc: info: service s6rc-oneshot-runner successfully stopped
```

The stopping sequence showed there is when you `docker stop [name_of_container]` a clean exit.

If you <kbd>Ctrl+C</kbd> the container exit with status 111.

```bash
…
^Cs6-rc: info: service legacy-services: stopping
s6-rc: info: service legacy-services successfully stopped
s6-rc: info: service legacy-cont-init: stopping
s6-rc: info: service legacy-cont-init successfully stopped
s6-rc: info: service fix-attrs: stopping
s6-rc: info: service fix-attrs successfully stopped
s6-rc: info: service s6rc-oneshot-runner: stopping
s6-rc: info: service s6rc-oneshot-runner successfully stopped
[gregr:~] 111 $ echo $?
111
```